### PR TITLE
Load pytorch from pytorch-nightly, not from conda-forge

### DIFF
--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -1,8 +1,8 @@
 name: ldm
 channels:
+  - pytorch-nightly
   - apple
   - conda-forge
-  - pytorch-nightly
   - defaults
 dependencies:
   - python=3.10.4


### PR DESCRIPTION
The order of the channels list is significant. The package is installed from the first channel where it is found. Since we want to install the nightly version of pytorch, it should appear in the list first.

See https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html for exact rules of priority.